### PR TITLE
Fix Scintilla.dll check

### DIFF
--- a/scint5.ahk
+++ b/scint5.ahk
@@ -332,7 +332,7 @@ class Scintilla extends Gui.Custom {
         
         scint_path := A_ScriptDir "\Scintilla.dll" ; Set this as needed.
         
-        If !(this.hModule := DllCall("LoadLibrary", "Str", scint_path), "UPtr") {    ; load dll, make sure it works
+        If !(this.hModule := DllCall("LoadLibrary", "Str", scint_path, "UPtr")) {    ; load dll, make sure it works
             MsgBox "Scintilla DLL not found.`n`nModify the path to the appropriate location for your script."
             ExitApp
         }


### PR DESCRIPTION
The misplaced parentheses causes a condition like `!(0, "uptr")`, so if Scintilla.dll is missing, this doesn't detect it.